### PR TITLE
Update coconut.vdom and related dependencies

### DIFF
--- a/app/coconut/.haxerc
+++ b/app/coconut/.haxerc
@@ -1,4 +1,4 @@
 {
-  "version": "4.0.5",
+  "version": "4.2.3",
   "resolveLibs": "scoped"
 }

--- a/app/coconut/build.hxml
+++ b/app/coconut/build.hxml
@@ -4,5 +4,6 @@ coconut.vdom.Renderer
 
 -lib coconut.vdom
 
+--macro addGlobalMetadata('coconut.diffing.internal', '@:keep', true, true, true)
 --macro addGlobalMetadata('coconut.vdom.Renderer.mountInto', '@:keep', false, false, true)
 --macro addGlobalMetadata('coconut.vdom.Renderer.mountInto', '@:expose("mount")', false, false, true)

--- a/app/coconut/haxe_libraries/coconut.data.hxml
+++ b/app/coconut/haxe_libraries/coconut.data.hxml
@@ -1,7 +1,8 @@
--D coconut.data=0.9.0
-# @install: lix --silent download "haxelib:/coconut.data#0.9.0" into coconut.data/0.9.0/haxelib
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.data#587d2c2dbc57cc24ecb52303c5e22eb97fed12cd" into coconut.data/0.12.1/github/587d2c2dbc57cc24ecb52303c5e22eb97fed12cd
 -lib tink_anon
--lib tink_lang
+-lib tink_priority
 -lib tink_pure
 -lib tink_state
--cp ${HAXE_LIBCACHE}/coconut.data/0.9.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/coconut.data/0.12.1/github/587d2c2dbc57cc24ecb52303c5e22eb97fed12cd/src
+-D coconut.data=0.12.1
+--macro coconut.data.macros.Setup.run()

--- a/app/coconut/haxe_libraries/coconut.diffing.hxml
+++ b/app/coconut/haxe_libraries/coconut.diffing.hxml
@@ -1,4 +1,4 @@
-# @install: lix --silent download "haxelib:/coconut.diffing#0.2.1" into coconut.diffing/0.2.1/haxelib
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.diffing#ef9c48de364701df9e656c35209dc2dfc0805b5a" into coconut.diffing/0.5.0/github/ef9c48de364701df9e656c35209dc2dfc0805b5a
 -lib coconut.ui
--cp ${HAXE_LIBCACHE}/coconut.diffing/0.2.1/haxelib/src
--D coconut.diffing=0.2.1
+-cp ${HAXE_LIBCACHE}/coconut.diffing/0.5.0/github/ef9c48de364701df9e656c35209dc2dfc0805b5a/src
+-D coconut.diffing=0.5.0

--- a/app/coconut/haxe_libraries/coconut.ui.hxml
+++ b/app/coconut/haxe_libraries/coconut.ui.hxml
@@ -1,8 +1,6 @@
-# @install: lix --silent download "haxelib:/coconut.ui#0.11.2" into coconut.ui/0.11.2/haxelib
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.ui#0a37e3d706e1773e6623c8d425f16d0b9c96bedd" into coconut.ui/0.12.0/github/0a37e3d706e1773e6623c8d425f16d0b9c96bedd
 -lib coconut.data
 -lib tink_anon
 -lib tink_hxx
--lib tink_lang
--cp ${HAXE_LIBCACHE}/coconut.ui/0.11.2/haxelib/src
--D coconut.ui=0.11.2
--D coconut_ui
+-cp ${HAXE_LIBCACHE}/coconut.ui/0.12.0/github/0a37e3d706e1773e6623c8d425f16d0b9c96bedd/src
+-D coconut.ui=0.12.0

--- a/app/coconut/haxe_libraries/coconut.vdom.hxml
+++ b/app/coconut/haxe_libraries/coconut.vdom.hxml
@@ -1,5 +1,5 @@
-# @install: lix --silent download "gh://github.com/MVCoconut/coconut.vdom#35a8d8d88553058151da69af3719a945df55894a" into coconut.vdom/0.8.1/github/35a8d8d88553058151da69af3719a945df55894a
+# @install: lix --silent download "gh://github.com/MVCoconut/coconut.vdom#c97e55cf3d17c8aa29b0c8e6365b1b5e9e07b76d" into coconut.vdom/0.10.0/github/c97e55cf3d17c8aa29b0c8e6365b1b5e9e07b76d
 -lib coconut.diffing
 -lib xDOM
--cp ${HAXE_LIBCACHE}/coconut.vdom/0.8.1/github/35a8d8d88553058151da69af3719a945df55894a/src
--D coconut.vdom=0.8.1
+-cp ${HAXE_LIBCACHE}/coconut.vdom/0.10.0/github/c97e55cf3d17c8aa29b0c8e6365b1b5e9e07b76d/src
+-D coconut.vdom=0.10.0

--- a/app/coconut/haxe_libraries/html-entities.hxml
+++ b/app/coconut/haxe_libraries/html-entities.hxml
@@ -1,3 +1,3 @@
--D html-entities=1.0.0
 # @install: lix --silent download "haxelib:/html-entities#1.0.0" into html-entities/1.0.0/haxelib
 -cp ${HAXE_LIBCACHE}/html-entities/1.0.0/haxelib/src
+-D html-entities=1.0.0

--- a/app/coconut/haxe_libraries/tink_anon.hxml
+++ b/app/coconut/haxe_libraries/tink_anon.hxml
@@ -1,4 +1,4 @@
-# @install: lix --silent download "haxelib:/tink_anon#0.5.0" into tink_anon/0.5.0/haxelib
+# @install: lix --silent download "gh://github.com/haxetink/tink_anon#3cceb2a4bd00bd5b9a4476cb889a37f1e178e805" into tink_anon/0.7.0/github/3cceb2a4bd00bd5b9a4476cb889a37f1e178e805
 -lib tink_macro
--cp ${HAXE_LIBCACHE}/tink_anon/0.5.0/haxelib/src
--D tink_anon=0.5.0
+-cp ${HAXE_LIBCACHE}/tink_anon/0.7.0/github/3cceb2a4bd00bd5b9a4476cb889a37f1e178e805/src
+-D tink_anon=0.7.0

--- a/app/coconut/haxe_libraries/tink_core.hxml
+++ b/app/coconut/haxe_libraries/tink_core.hxml
@@ -1,3 +1,3 @@
-# @install: lix --silent download "haxelib:/tink_core#1.26.0" into tink_core/1.26.0/haxelib
--cp ${HAXE_LIBCACHE}/tink_core/1.26.0/haxelib/src
--D tink_core=1.26.0
+# @install: lix --silent download "haxelib:/tink_core#2.0.2" into tink_core/2.0.2/haxelib
+-cp ${HAXE_LIBCACHE}/tink_core/2.0.2/haxelib/src
+-D tink_core=2.0.2

--- a/app/coconut/haxe_libraries/tink_csss.hxml
+++ b/app/coconut/haxe_libraries/tink_csss.hxml
@@ -1,4 +1,4 @@
--D tink_csss=0.2.2
-# @install: lix --silent download "haxelib:/tink_csss#0.2.2" into tink_csss/0.2.2/haxelib
+# @install: lix --silent download "haxelib:/tink_csss#0.2.3" into tink_csss/0.2.3/haxelib
 -lib tink_parse
--cp ${HAXE_LIBCACHE}/tink_csss/0.2.2/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_csss/0.2.3/haxelib/src
+-D tink_csss=0.2.3

--- a/app/coconut/haxe_libraries/tink_domspec.hxml
+++ b/app/coconut/haxe_libraries/tink_domspec.hxml
@@ -1,5 +1,5 @@
--D tink_domspec=0.1.6
-# @install: lix --silent download "haxelib:/tink_domspec#0.1.6" into tink_domspec/0.1.6/haxelib
+# @install: lix --silent download "haxelib:/tink_domspec#0.3.1" into tink_domspec/0.3.1/haxelib
 -lib tink_macro
 -lib tink_svgspec
--cp ${HAXE_LIBCACHE}/tink_domspec/0.1.6/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_domspec/0.3.1/haxelib/src
+-D tink_domspec=0.3.1

--- a/app/coconut/haxe_libraries/tink_hxx.hxml
+++ b/app/coconut/haxe_libraries/tink_hxx.hxml
@@ -1,6 +1,6 @@
-# @install: lix --silent download "haxelib:/tink_hxx#0.23.0" into tink_hxx/0.23.0/haxelib
+# @install: lix --silent download "gh://github.com/haxetink/tink_hxx#0d6cda883d5ef4c1186dbad476e016b98aad68b8" into tink_hxx/0.25.0/github/0d6cda883d5ef4c1186dbad476e016b98aad68b8
 -lib html-entities
 -lib tink_anon
 -lib tink_parse
--cp ${HAXE_LIBCACHE}/tink_hxx/0.23.0/haxelib/src
--D tink_hxx=0.23.0
+-cp ${HAXE_LIBCACHE}/tink_hxx/0.25.0/github/0d6cda883d5ef4c1186dbad476e016b98aad68b8/src
+-D tink_hxx=0.25.0

--- a/app/coconut/haxe_libraries/tink_macro.hxml
+++ b/app/coconut/haxe_libraries/tink_macro.hxml
@@ -1,4 +1,4 @@
-# @install: lix --silent download "haxelib:/tink_macro#0.19.0" into tink_macro/0.19.0/haxelib
+# @install: lix --silent download "haxelib:/tink_macro#1.0.0" into tink_macro/1.0.0/haxelib
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_macro/0.19.0/haxelib/src
--D tink_macro=0.19.0
+-cp ${HAXE_LIBCACHE}/tink_macro/1.0.0/haxelib/src
+-D tink_macro=1.0.0

--- a/app/coconut/haxe_libraries/tink_parse.hxml
+++ b/app/coconut/haxe_libraries/tink_parse.hxml
@@ -1,4 +1,4 @@
--D tink_parse=0.3.1
-# @install: lix --silent download "haxelib:/tink_parse#0.3.1" into tink_parse/0.3.1/haxelib
+# @install: lix --silent download "haxelib:/tink_parse#0.4.1" into tink_parse/0.4.1/haxelib
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_parse/0.3.1/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_parse/0.4.1/haxelib/src
+-D tink_parse=0.4.1

--- a/app/coconut/haxe_libraries/tink_pure.hxml
+++ b/app/coconut/haxe_libraries/tink_pure.hxml
@@ -1,5 +1,5 @@
--D tink_pure=0.5.1
-# @install: lix --silent download "haxelib:/tink_pure#0.5.1" into tink_pure/0.5.1/haxelib
+# @install: lix --silent download "gh://github.com/haxetink/tink_pure#2020b8c97e87f4555020d51638264272bc294e7b" into tink_pure/0.6.0/github/2020b8c97e87f4555020d51638264272bc294e7b
 -lib tink_core
 -lib tink_slice
--cp ${HAXE_LIBCACHE}/tink_pure/0.5.1/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_pure/0.6.0/github/2020b8c97e87f4555020d51638264272bc294e7b/src
+-D tink_pure=0.6.0

--- a/app/coconut/haxe_libraries/tink_slice.hxml
+++ b/app/coconut/haxe_libraries/tink_slice.hxml
@@ -1,4 +1,4 @@
--D tink_slice=0.1.0
-# @install: lix --silent download "haxelib:/tink_slice#0.1.0" into tink_slice/0.1.0/haxelib
+# @install: lix --silent download "gh://github.com/haxetink/tink_slice#a94d31c50a567c5f22f704c0584a89d416bac953" into tink_slice/0.2.0/github/a94d31c50a567c5f22f704c0584a89d416bac953
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_slice/0.1.0/haxelib/src
+-cp ${HAXE_LIBCACHE}/tink_slice/0.2.0/github/a94d31c50a567c5f22f704c0584a89d416bac953/src
+-D tink_slice=0.2.0

--- a/app/coconut/haxe_libraries/tink_state.hxml
+++ b/app/coconut/haxe_libraries/tink_state.hxml
@@ -1,4 +1,4 @@
-# @install: lix --silent download "gh://github.com/haxetink/tink_state#2c1770b52411491e8aaba22cb8b85ddad1dc9ccb" into tink_state/0.11.0/github/2c1770b52411491e8aaba22cb8b85ddad1dc9ccb
+# @install: lix --silent download "gh://github.com/haxetink/tink_state#b01eb8bd47f7264420604b5f8816dde69e5dec55" into tink_state/1.0.0-beta.3/github/b01eb8bd47f7264420604b5f8816dde69e5dec55
 -lib tink_core
--cp ${HAXE_LIBCACHE}/tink_state/0.11.0/github/2c1770b52411491e8aaba22cb8b85ddad1dc9ccb/src
--D tink_state=0.11.0
+-cp ${HAXE_LIBCACHE}/tink_state/1.0.0-beta.3/github/b01eb8bd47f7264420604b5f8816dde69e5dec55/src
+-D tink_state=1.0.0-beta.3

--- a/app/coconut/haxe_libraries/tink_svgspec.hxml
+++ b/app/coconut/haxe_libraries/tink_svgspec.hxml
@@ -1,3 +1,3 @@
--D tink_svgspec=0.0.1
 # @install: lix --silent download "haxelib:/tink_svgspec#0.0.1" into tink_svgspec/0.0.1/haxelib
 -cp ${HAXE_LIBCACHE}/tink_svgspec/0.0.1/haxelib/src
+-D tink_svgspec=0.0.1

--- a/app/coconut/haxe_libraries/xDOM.hxml
+++ b/app/coconut/haxe_libraries/xDOM.hxml
@@ -1,5 +1,5 @@
--D xDOM=0.2.1
-# @install: lix --silent download "haxelib:/xDOM#0.2.1" into xDOM/0.2.1/haxelib
+# @install: lix --silent download "haxelib:/xDOM#0.2.2" into xDOM/0.2.2/haxelib
 -lib tink_csss
 -lib tink_domspec
--cp ${HAXE_LIBCACHE}/xDOM/0.2.1/haxelib/src
+-cp ${HAXE_LIBCACHE}/xDOM/0.2.2/haxelib/src
+-D xDOM=0.2.2


### PR DESCRIPTION
The current version of storybook-coconut is not rendering components on screen. 
I found updating the underlying `coconut.vdom` library resolves the issue. 


The Haxe version also needed to be updated to run the build, though some warnings from `xDOM` will be displayed.
```
.../haxe/haxe_libraries/xDOM/0.2.2/haxelib/src/xdom/html/EventSource.hx:20: characters 28-57 : Warning : Use cancel() instead
.../haxe/haxe_libraries/xDOM/0.2.2/haxelib/src/xdom/html/EventSource.hx:27: lines 27-29 : Warning : Use new Signal() instead
.../haxe/haxe_libraries/xDOM/0.2.2/haxelib/src/xdom/html/EventSource.hx:111: characters 12-36 : Warning : Use cancel() instead
.../haxe/haxe_libraries/xDOM/0.2.2/haxelib/src/xdom/html/EventSource.hx:121: characters 7-22 : Warning : Use cancel() instead
```

**Update:**
Also noticed after getting this rendered, components with state are not updating and seeing the following error

```
[Error] TypeError: _g.scheduleUpdate is not a function. (In '_g.scheduleUpdate(this)', '_g.scheduleUpdate' is undefined)
	invalidateParent (main.ea45db6cff82a2a6ae1e.bundle.js:1450)
	scheduleUpdate (main.ea45db6cff82a2a6ae1e.bundle.js:1428)
	invalidateParent (main.ea45db6cff82a2a6ae1e.bundle.js:1450)
	invalidate (main.ea45db6cff82a2a6ae1e.bundle.js:2032)
	...
```
**Update 2**: Fixed this by adding `@:keep` to `coconut.diffing.internal`  there's probably a better solution I suppose just let me know.

